### PR TITLE
fix: Convert hireDate string to Date object in user update

### DIFF
--- a/apps/bff/src/modules/users/users.service.ts
+++ b/apps/bff/src/modules/users/users.service.ts
@@ -240,6 +240,7 @@ export class UsersService {
       where: { id },
       data: {
         ...updateUserDto,
+        hireDate: updateUserDto.hireDate ? new Date(updateUserDto.hireDate) : undefined,
         emergencyContact: updateUserDto.emergencyContact || existingUser.emergencyContact,
       },
       include: {


### PR DESCRIPTION
- Fix Prisma validation error when updating users with hireDate
- Add date conversion in user update method similar to create method
- Resolves 'premature end of input' DateTime validation error

🤖 Generated with [Claude Code](https://claude.ai/code)